### PR TITLE
Allow specifying PORT env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -33,8 +34,15 @@ import (
 //go:embed build/web
 var web embed.FS
 
+func str(key, def string) string {
+	if v := os.Getenv(key); v != `` {
+		return v
+	}
+	return def
+}
+
 var (
-	port = flag.String("port", ":8081", "port to serve from")
+	port = flag.String("port", ":"+str("PORT", "8081"), "port to serve from")
 	skip = flag.Bool("skip", true, "should the proxy skip ssl verify")
 	tout = flag.Duration("tout", time.Second, "cache expiration timeout")
 )

--- a/ship.sh
+++ b/ship.sh
@@ -14,5 +14,5 @@ $DKR google/dart:2 ./ship.sh dart
 go build -o status -ldflags="-s -w" -v .
 gzip -f status
 scp status.gz me.bign8.info:/opt/bign8
-ssh me.bign8.info -- sudo systemctl restart status
+ssh me.bign8.info -- sudo systemctl restart bign8@status.service
 rm status.gz


### PR DESCRIPTION
With the new hosting guidelines, it's recommended to have services host on `PORT` environment variable.